### PR TITLE
Make bower-tokenfield install without warnings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,8 @@
     "form"
   ],
   "dependencies": {
-    "jquery": "~2.1.0",
-    "bootstrap": "~3.1.1"
+    "jquery": "^2.1.0",
+    "bootstrap": "^3.1.1 || ^4.0"
   },
   "devDependecies": {
     "mocha": "~1.12.*",


### PR DESCRIPTION
Cryptpad obviously works with this fork of bower-tokenfield. However, its installation causes warnings: https://github.com/xwiki-labs/cryptpad/issues/641. This change updates the claimed supported version range of bower-tokenfield so that it is version-compatible with cryptpad.